### PR TITLE
HTTP version is 2.0.

### DIFF
--- a/test/toofz.Steam.Tests/HttpRequestMessageExtensionsTests.cs
+++ b/test/toofz.Steam.Tests/HttpRequestMessageExtensionsTests.cs
@@ -32,7 +32,7 @@ namespace toofz.Steam.Tests
                 var clone = await request.CloneAsync();
 
                 // Assert
-                Assert.Equal(new Version("1.1"), clone.Version);
+                Assert.Equal(new Version("2.0"), clone.Version);
             }
 
             [DisplayFact(nameof(HttpRequestMessage.Content))]


### PR DESCRIPTION
Not sure why this changed. Is it platform dependent?