### PR TITLE
Disable publishing code coverage temporarily.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,8 @@ test_script:
           /target:Rebuild `
           /target:Test `
           /property:Configuration=Coverage `
-          /property:DebugType=full
+          /property:DebugType=full `
+          /property:PublishCoverage=false
 
 deploy_script:
   - ps: |


### PR DESCRIPTION
There is an issue with publishing code coverage results. Publishing is disabled temporarily in order to unblock the build.